### PR TITLE
chart: updated Vault version, pin bank-vaults version

### DIFF
--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -245,7 +245,7 @@ vault:
 unsealer:
   image:
     repository: ghcr.io/banzaicloud/bank-vaults
-    # tag: ""
+    tag: "1.19.0"
     pullPolicy: IfNotPresent
   args:
     [

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -10,7 +10,7 @@ strategy:
   type: RollingUpdate
 image:
   repository: vault
-  tag: 1.6.2
+  tag: 1.13.3
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Closes #3 
Closes #6

Updated versions in the chart:
- updated Vault version to latest (1.6.2->1.13.3)
- pinned latest stable bank-vaults version