### PR TITLE
feat: Allow for TLS in other namespaces

### DIFF
--- a/vault/templates/secret.yaml
+++ b/vault/templates/secret.yaml
@@ -3,7 +3,9 @@
 {{- $externalDNS := print $cn "." .Release.Namespace -}}
 {{- $ca := genCA "vault-ca" 365 -}}
 {{- $cert := genSignedCert $cn (list "127.0.0.1") (list $cn $externalDNS) 365 $ca -}}
-{{- range $i, $namespace := .Values.tls.namespaces }}
+{{- $caNamespaces := list .Release.Namespace -}}
+{{- if .Values.tls.caNamespaces }}{{ $caNamespaces = (concat $caNamespaces .Values.tls.caNamespaces ) | uniq }}{{ end -}}
+{{- range $i, $namespace := $caNamespaces }}
 {{- if $i }}{{ printf "\n---\n" }}{{ end -}}
 apiVersion: v1
 kind: Secret

--- a/vault/templates/secret.yaml
+++ b/vault/templates/secret.yaml
@@ -5,8 +5,8 @@
 {{- $cert := genSignedCert $cn (list "127.0.0.1") (list $cn $externalDNS) 365 $ca -}}
 {{- $caNamespaces := list .Release.Namespace -}}
 {{- if .Values.tls.caNamespaces }}{{ $caNamespaces = (concat $caNamespaces .Values.tls.caNamespaces ) | uniq }}{{ end -}}
-{{- range $i, $namespace := $caNamespaces }}
-{{- if $i }}{{ printf "\n---\n" }}{{ end -}}
+{{- range $namespace := $caNamespaces }}
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/vault/templates/secret.yaml
+++ b/vault/templates/secret.yaml
@@ -1,24 +1,27 @@
 {{- if and (not .Values.tls.secretName) (not .Values.certManager.certificate.enabled) }}
-{{- $cn := include "vault.fullname" . -}}
+{{- $cn := include "vault.fullname" $ -}}
 {{- $externalDNS := print $cn "." .Release.Namespace -}}
 {{- $ca := genCA "vault-ca" 365 -}}
 {{- $cert := genSignedCert $cn (list "127.0.0.1") (list $cn $externalDNS) 365 $ca -}}
+{{- range $i, $namespace := .Values.tls.namespaces }}
+{{- if $i }}{{ printf "\n---\n" }}{{ end -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "vault.fullname" . }}-tls
-  namespace: {{ .Release.Namespace }}
+  name: {{ $cn }}-tls
+  namespace: {{ $namespace }}
   labels:
-    helm.sh/chart: {{ template "vault.chart" . }}
-    app.kubernetes.io/name: {{ template "vault.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "vault.chart" $ }}
+    app.kubernetes.io/name: {{ template "vault.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
 data:
   ca.crt: {{ $ca.Cert | b64enc }}
   ca.key: {{ $ca.Key | b64enc }}
   server.crt: {{ $cert.Cert | b64enc }}
   server.key: {{ $cert.Key | b64enc }}
-{{ end }}
+{{- end }}
+{{- end }}
 
 ---
 

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -129,11 +129,19 @@ extraContainerVolumes: []
 # - name: empty-dir-volume
 #   emptyDir: {}
 
-# Specify a secret which holds your custom TLS certificate.
-# If not specified Helm will generate one for you.
-# See templates/secret.yaml for the exact format.
 tls:
+  # Specify a secret which holds your custom TLS certificate.
+  # If not specified Helm will generate one for you.
+  # See templates/secret.yaml for the exact format.
   secretName: ""
+
+  # Allows using TLS to pull Vault secrets from other namespaces
+  # You can pass a list of namespaces here
+  namespaces: [default]
+  # namespaces:
+  #   - default
+  #   - namespace1
+  #   - namespace1
 
 vault:
   # Allows the mounting of various custom secrets to enable production vault

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -135,13 +135,10 @@ tls:
   # See templates/secret.yaml for the exact format.
   secretName: ""
 
-  # Allows using TLS to pull Vault secrets from other namespaces
-  # You can pass a list of namespaces here
-  namespaces: [default]
-  # namespaces:
-  #   - default
-  #   - namespace1
-  #   - namespace1
+  # Support for distributing the generated CA certificate Secret to other namespaces.
+  # Define a list of namespaces
+  caNamespaces:
+    - default
 
 vault:
   # Allows the mounting of various custom secrets to enable production vault

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -137,8 +137,8 @@ tls:
 
   # Support for distributing the generated CA certificate Secret to other namespaces.
   # Define a list of namespaces
-  caNamespaces:
-    - default
+  caNamespaces: []
+  #   - default
 
 vault:
   # Allows the mounting of various custom secrets to enable production vault


### PR DESCRIPTION
Allow for TLS usage in other namespaces without the use of CRDs

The current implementation of using TLS in other namespaces involves the usage of CRDs. This PR allows for the deployment of the `vault-tls` secret to other namespaces, so that applications hosted in other namespaces can also use TLS for fetching secrets from Vault.