### PR TITLE
chore: Use verified publisher image `hashicorp/vault`

### DIFF
--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 strategy:
   type: RollingUpdate
 image:
-  repository: vault
+  repository: hashicorp/vault
   tag: 1.13.3
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
From https://hub.docker.com/_/vault/:

> DEPRECATION NOTICE
> Upcoming in Vault 1.14, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from [hashicorp/vault](https://hub.docker.com/r/hashicorp/vault) instead of [vault](https://hub.docker.com/_/vault). Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/vault.

Hence updated the `image.repository` value.


Note: [Vault 1.14 is already released](https://github.com/hashicorp/vault/releases/tag/v1.14.0).