### PR TITLE
chore: Update Vault to 1.14.0

### DIFF
--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -10,7 +10,7 @@ strategy:
   type: RollingUpdate
 image:
   repository: hashicorp/vault
-  tag: 1.13.3
+  tag: 1.14.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Update `hashicorp/vault` to `1.14.0` (latest version)