### PR TITLE
feat: Allow Velero container creation

### DIFF
--- a/vault/templates/statefulset.yaml
+++ b/vault/templates/statefulset.yaml
@@ -33,6 +33,9 @@ spec:
 {{- with .Values.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- if .Values.velero.enabled }}
+{{ toYaml .Values.velero.annotations | indent 8 }}
+{{- end }}
     spec:
       initContainers:
       - name: vault-config
@@ -254,6 +257,14 @@ spec:
           mountPath: /tmp/
         resources:
 {{ toYaml .Values.prometheusStatsdExporter.resources | indent 10 }}
+{{- end }}
+{{- if .Values.velero.enabled }}
+      - name: velero-fsfreeze
+        image: "{{ .Values.velero.image.repository }}:{{ .Values.velero.image.tag }}"
+        imagePullPolicy: {{ .Values.velero.image.pullPolicy }}
+        command: ["/bin/bash", "-c", "sleep infinity"]
+        resources:
+{{ toYaml .Values.velero.resources | indent 10 }}
 {{- end }}
 {{- if .Values.extraContainers }}
 {{ toYaml .Values.extraContainers | indent 6}}

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -327,6 +327,27 @@ statsd:
       enabled: false
       additionalLabels: {}
 
+# Add Velero fsfreeze sidecar container and supporting hook annotations to Vault Pods:
+# https://velero.io/docs/v1.11/backup-hooks/
+velero:
+  enabled: false
+  image:
+    repository: ubuntu
+    tag: bionic
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 50m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 32Mi
+  annotations:
+    pre.hook.backup.velero.io/container:  "velero-fsfreeze"
+    pre.hook.backup.velero.io/command:    "[\"/sbin/fsfreeze\", \"--freeze\", \"/vault/file/\"]"
+    post.hook.backup.velero.io/container: "velero-fsfreeze"
+    post.hook.backup.velero.io/command:   "[\"/sbin/fsfreeze\", \"--unfreeze\", \"/vault/file/\"]"
+
 rbac:
   psp:
     # -- Use pod security policy


### PR DESCRIPTION
Allow Velero container creation without the use of CRDs

Referred to config at https://github.com/bank-vaults/vault-operator/blob/main/pkg/controller/vault/vault_controller.go