### PR TITLE
chore: Update to `hashicorp/vault:1.14.1`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       matrix:
         k8s_version: ["v1.24.15", "v1.25.11", "v1.26.6", "v1.27.3"]
-        vault_version: ["1.11.12", "1.12.8", "1.13.4", "1.14.0"]
+        vault_version: ["1.11.12", "1.12.8", "1.13.4", "1.14.1"]
 
     steps:
       - name: Checkout repository

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -10,7 +10,7 @@ strategy:
   type: RollingUpdate
 image:
   repository: hashicorp/vault
-  tag: 1.14.0
+  tag: 1.14.1
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Update to `hashicorp/vault:1.14.1` due to bug: https://github.com/hashicorp/vault/issues/21465