### PR TITLE
fix: remove workaround for default storage

### DIFF
--- a/vault/templates/secret.yaml
+++ b/vault/templates/secret.yaml
@@ -39,10 +39,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 data:
   config.json:
-    {{ if .Values.vault.config.storage }}
     {{ .Values.vault.config | toPrettyJson | b64enc }}
-    {{ else }}
-    {{ (merge .Values.vault.config .Values.vault.defaultStorage) | toPrettyJson | b64enc }}
-    {{ end }}
   vault-config.yml:
     {{ .Values.vault.externalConfig | toYaml | b64enc }}

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -190,9 +190,9 @@ vault:
 
     # Check https://www.vaultproject.io/docs/configuration/storage/ for supported storage backends.
     # @ignored
-    storage: {}
-      # file:
-      #   path: "/vault/file"
+    storage:
+      file:
+        path: "/vault/file"
       #
       # consul:
       #   address: ""
@@ -254,14 +254,6 @@ vault:
         description: General secrets.
         options:
           version: 2
-
-  # Until this issue is fixed: https://github.com/kubernetes/helm/issues/3117
-  # we have to workaround the default storage problem.
-  # @ignored
-  defaultStorage:
-    storage:
-      file:
-        path: "/vault/file"
 
   # @ignored
   logLevel: info


### PR DESCRIPTION
## Overview

- The reason why the workaround was added, has been fixed in helm/helm#3912
- Manually tested whether the storage gets dropped after the storage has been set to null:
<img width="1198" alt="image" src="https://github.com/bank-vaults/vault-helm-chart/assets/113284287/418af5aa-273d-4a62-8279-3f66c002132d">


Fixes #25 

