### PR TITLE
fix: remove file storage block from default values

### DIFF
--- a/vault/templates/secret.yaml
+++ b/vault/templates/secret.yaml
@@ -39,6 +39,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 data:
   config.json:
-    {{ .Values.vault.config | toPrettyJson | b64enc }}
+    {{- if .Values.vault.config.storage }}
+    {{ .Values.vault.config | toPrettyJson | b64enc -}}
+    {{ end }}
   vault-config.yml:
     {{ .Values.vault.externalConfig | toYaml | b64enc }}

--- a/vault/templates/secret.yaml
+++ b/vault/templates/secret.yaml
@@ -40,7 +40,9 @@ metadata:
 data:
   config.json:
     {{- if .Values.vault.config.storage }}
-    {{ .Values.vault.config | toPrettyJson | b64enc -}}
-    {{ end }}
+    {{ .Values.vault.config | toPrettyJson | b64enc }}
+    {{- else }}
+    {{ (merge .Values.vault.config .Values.vault.config.defaultStorage) | toPrettyJson | b64enc }}
+    {{- end }}
   vault-config.yml:
     {{ .Values.vault.externalConfig | toYaml | b64enc }}

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -190,9 +190,9 @@ vault:
 
     # Check https://www.vaultproject.io/docs/configuration/storage/ for supported storage backends.
     # @ignored
-    storage:
-      file:
-        path: "/vault/file"
+    storage: {}
+      # file:
+      #   path: "/vault/file"
       #
       # consul:
       #   address: ""

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -214,6 +214,11 @@ vault:
       #   credentials_file: ""
       #   ha_enabled: "true"
       #
+    ## Helm merges the default chart values under vault.config.storage with the supplied storage value when generating the config.json for vault. This causes the vault container to error out due to the multiple storage blocks. We add defaultStorage block as a workaround for now
+    defaultStorage:
+      storage:
+        file:
+          path: "/vault/file"
 
     ## @ignored
     # api_addr: http://localhost:8200


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Helm merges the default chart values under `vault.config.storage` with the supplied storage value when generating the config.json for vault. This causes the vault container to error out due to the multiple storage blocks.
We can do without the default chart value for config.storage and instead require the user to supply the value 
Example of supplied values with a storage block included:
```yaml
vault:
  vault:
    config: 
      storage:
        dynamodb:
          ha_enabled: true
          region: us-east-1
          table: "vault-backend"
```
Resulting config.json
```json
{
  ...
  "storage": {
    "dynamodb": {
      "ha_enabled": true,
      "region": "us-east-1",
      "table": "vault-backend"
    }
  },
 ...
}
```
Fixes https://github.com/bank-vaults/vault-helm-chart/issues/180
## Notes for reviewer

<!-- Anything the reviewer should know? -->
