### PR TITLE
chore: remove obsolete build tags

### DIFF
--- a/test/acceptance_test.go
+++ b/test/acceptance_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build kubeall || helm
-// +build kubeall helm
 
 // Fire up a local Kubernetes cluster (`kind create cluster --config test/kind.yaml`)
 // and run the acceptance tests against it (`go test -v -tags kubeall ./test`)


### PR DESCRIPTION
## Overview

- Removes obsolete build tag.

Fixes: https://github.com/orgs/bank-vaults/projects/2/views/1?pane=issue&itemId=38350173
