### PR TITLE
fix: add resources field to test-vault-status and secret-cleanup containers

### DIFF
--- a/vault/README.md
+++ b/vault/README.md
@@ -203,6 +203,8 @@ The following table lists the configurable parameters of the Helm chart.
 | `serviceAccount.secretCleanupImage.tag` | string | `"1.35.5"` | secret-cleanup Job image tag |
 | `serviceAccount.secretCleanupImage.pullPolicy` | string | `"IfNotPresent"` | secret-cleanup Job image pull policy |
 | `serviceAccount.secretCleanupImage.pullSecrets` | list | `[]` | Container image pull secrets |
+| `serviceAccount.secretCleanupImage.resources` | object | `{}` | Resources to request for the secret-cleanup Job container |
+| `testVaultStatus.resources` | object | `{}` | Resources to request for the test-vault-status container |
 | `vaultConfig.containerSecurityContext` | object | `{"enabled":false}` | SecurityContext capabilities to add to the unsealer container |
 | `vaultConfig.containerSecurityContext.enabled` | bool | `false` | Enable container security context |
 | `vaultUnsealer.containerSecurityContext` | object | `{"enabled":false}` | SecurityContext capabilities to add to the unsealer container |

--- a/vault/templates/secret-cleanup.yaml
+++ b/vault/templates/secret-cleanup.yaml
@@ -27,5 +27,7 @@ spec:
           - -c
           - >
               kubectl delete secret {{ include "vault.unsealer.secretName" . }} --ignore-not-found=true
+          resources:
+{{ toYaml .Values.serviceAccount.secretCleanupImage.resources | indent 12 }}
       restartPolicy: OnFailure
 {{- end }}

--- a/vault/templates/tests/test-vault-status.yaml
+++ b/vault/templates/tests/test-vault-status.yaml
@@ -19,4 +19,6 @@ spec:
         value: https://{{ template "vault.fullname" . }}:8200
       {{- end }}
     command: ["sh", "-c", "vault status"]
+    resources:
+{{ toYaml .Values.testVaultStatus.resources | indent 6 }}
   restartPolicy: Never

--- a/vault/values.yaml
+++ b/vault/values.yaml
@@ -391,7 +391,13 @@ serviceAccount:
     # -- Container image pull secrets
     pullSecrets: []
       # - name: myregistrykey
+    # -- Resources to request for the secret-cleanup Job container
+    resources: {}
 
+# -- Configuration for the `test-vault-status` Helm test hook Pod
+testVaultStatus:
+  # -- Resources to request for the test-vault-status container
+  resources: {}
 
 vaultConfig:
   # -- (object) SecurityContext capabilities to add to the unsealer container


### PR DESCRIPTION
## Summary

Every container in this chart reads its `resources` from a dedicated values key (`vaultConfig.resources`, `vaultUnsealer.resources`, `vaultConfigurer.resources`, `prometheusStatsdExporter.resources`, and the main vault container's top-level `.Values.resources`), except two:

- `templates/tests/test-vault-status.yaml` (the `test-success` helm test hook Pod)
- `templates/secret-cleanup.yaml` (the `pre-delete` hook Job)

These had no `resources` field and no values-level control point, so policy/compliance scanners (e.g. Kubescape `unset-cpu-requirements` / `unset-memory-requirements`) flag both Pods.

This PR adds `testVaultStatus.resources` and `serviceAccount.secretCleanupImage.resources` values (defaulting to `{}`, matching the existing convention for other containers) and wires them into the two templates the same way the rest of the chart does.

## Test plan

- [x] `helm lint vault` passes
- [x] `helm template` renders both hooks correctly with default (`{}`) resources
- [x] `helm template --set testVaultStatus.resources.requests.cpu=50m --set testVaultStatus.resources.requests.memory=64Mi --set serviceAccount.secretCleanupImage.resources.limits.memory=128Mi` renders the expected `resources:` blocks with correct indentation
- [x] `README.md` values table updated for the two new keys

Fixes #443